### PR TITLE
remove requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-requests

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,6 @@
-from pip.req import parse_requirements
 from setuptools import setup, find_packages
 
 from helga_urbandictionary import __version__ as version
-
-requirements = [
-    str(req.req) for req in parse_requirements('requirements.txt')
-]
 
 setup(
     name='helga-urbandictionary',
@@ -28,7 +23,9 @@ setup(
     include_package_data=True,
     py_modules=['helga_urbandictionary.plugin'],
     zip_safe=True,
-    install_requires=requirements,
+    install_requires=[
+        'requests',
+    ],
     entry_points = dict(
         helga_plugins=[
             'urbandictionary = helga_urbandictionary.plugin:urbandictionary',


### PR DESCRIPTION
I tried to install this plugin, and got an error when it was trying to process requirements.txt

turns out, parse_requirements change recently, but instead of fixing it, i just removed requirements.txt and put it in install_requires.